### PR TITLE
feat: add pr-commenter

### DIFF
--- a/.github/workflows/test-pull-request-comment.yml
+++ b/.github/workflows/test-pull-request-comment.yml
@@ -1,0 +1,62 @@
+name: test-pr-comment
+
+on:
+  push:
+    paths:
+      - "pr-comment/**"
+      - ".github/workflows/test-pr-comment.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "pr-comment/**"
+      - ".github/workflows/test-pr-comment.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test-comment:
+    name: test-comment
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: generate comment
+        id: generate
+        run: |
+          echo "comment=Triggered on $(date -u) [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "$GITHUB_OUTPUT"
+      - name: comment
+        id: comment_default_search
+        uses: ./pr-comment
+        with:
+          issue_number: 6
+          body: |
+            comment_default_search - ${{ steps.generate.outputs.comment }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: comment
+        id: comment_search
+        uses: ./pr-comment
+        with:
+          issue_number: 6
+          body: |
+            comment_search -  ${{ steps.generate.outputs.comment }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          search_term: "test-comment-with-search-term"
+      - name: assert output
+        id: assert
+        run: |
+          if [[ -z "${{ steps.comment_default_search.outputs.comment-id }}" ]]; then
+            echo "::error::comment-id not set by comment_default_search"
+            exit 1
+          fi
+          if [[ -z "${{ steps.comment_search.outputs.comment-id }}" ]]; then
+            echo "::error::comment-id not set by comment_search"
+            exit 1
+          fi

--- a/.github/workflows/test-pull-request-comment.yml
+++ b/.github/workflows/test-pull-request-comment.yml
@@ -5,12 +5,6 @@ on:
     paths:
       - "pr-comment/**"
       - ".github/workflows/test-pr-comment.yml"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "pr-comment/**"
-      - ".github/workflows/test-pr-comment.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/pr-comment/action.yml
+++ b/pr-comment/action.yml
@@ -1,0 +1,70 @@
+name: PR Commenter
+description: Creates or Updates a comment on a pull request.
+inputs:
+  body:
+    description: The contents of the comment
+    required: false
+  body_path:
+    description: A file location that contains the body to be used as the comment
+    required: false
+  issue_number:
+    description: The issue number to use, if not set will try and use value in github context.
+    required: false
+  search_term:
+    description: |
+      The search term that allows us to update an existing comment; if not found then a new comment is created
+    required: false
+    default: "pr-comment: workflow=${{ github.workflow }} job=${{ github.job }}"
+  repository:
+    description: Override the repository (your token needs to allow it) default is 'github.repository'
+    required: false
+    default: ${{ github.repository }}
+  token:
+    description: The GITHUB token to use default is github.token
+    default: ${{ github.token }}
+  edit_mode:
+    description: |
+      The edit mode to use when updating an existing comment. Valid values are 'replace' and 'append'.
+      If not set, the default is 'replace'.
+    required: false
+    default: "replace"
+outputs:
+  comment_id:
+    description: The ID of the comment that was created or updated.
+    value: ${{ steps.comment.outputs.comment-id || steps.search.outputs.comment-id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Search existing
+      id: search
+      uses: peter-evans/find-comment@v2.3.0
+      with:
+        issue-number: ${{ inputs.issue_number || github.event.issue.number }}
+        body-includes: ${{ inputs.search_term }}
+        token: ${{ inputs.token }}
+        repository: ${{ inputs.repository}}
+    - name: generate comment body
+      id: body
+      shell: bash
+      run: |
+        comment_body_file=$(mktemp --tmpdir="$RUNNER_TEMP" "pr-comment-XXXXXXXX")
+        echo "comment_body_file=$comment_body_file" >> "$GITHUB_OUTPUT"
+        if [[ -n "${{ inputs.body_path }}" ]]; then
+          cat "${{ inputs.body_path }}" >> "$comment_body_file"
+        else
+          echo "${{ inputs.body }}" >> "$comment_body_file"
+        fi
+        {
+          printf '\n%s\n' "<!-- ${{ inputs.search_term }} -->"
+        } >> $comment_body_file
+    - name: Write Comment
+      id: comment
+      uses: peter-evans/create-or-update-comment@v3.0.2
+      with:
+        token: ${{ inputs.token }}
+        repository: ${{ inputs.repository}}
+        issue-number: ${{ inputs.issue_number }}
+        comment-id: ${{ steps.search.outputs.comment-id }}}
+        body-path: ${{ steps.body.outputs.comment_body_file }}
+        edit-mode: ${{ inputs.edit_mode }}

--- a/pr-comment/action.yml
+++ b/pr-comment/action.yml
@@ -50,12 +50,12 @@ runs:
       run: |
         comment_body_file=$(mktemp --tmpdir="$RUNNER_TEMP" "pr-comment-XXXXXXXX")
         echo "comment_body_file=$comment_body_file" >> "$GITHUB_OUTPUT"
-        if [[ -n "${{ inputs.body_path }}" ]]; then
-          cat "${{ inputs.body_path }}" >> "$comment_body_file"
-        else
-          echo "${{ inputs.body }}" >> "$comment_body_file"
-        fi
         {
+          if [[ -n "${{ inputs.body_path }}" ]]; then
+            cat "${{ inputs.body_path }}"
+          else
+            printf '%s' "${{ inputs.body }}"
+          fi
           printf '\n%s\n' "<!-- ${{ inputs.search_term }} -->"
         } >> $comment_body_file
     - name: Write Comment

--- a/pr-comment/action.yml
+++ b/pr-comment/action.yml
@@ -38,16 +38,19 @@ runs:
   steps:
     - name: Search existing
       id: search
-      uses: peter-evans/find-comment@v2.3.0
+      uses: peter-evans/find-comment@v2.4.0
       with:
         issue-number: ${{ inputs.issue_number || github.event.issue.number }}
         body-includes: ${{ inputs.search_term }}
         token: ${{ inputs.token }}
-        repository: ${{ inputs.repository}}
+        repository: ${{ inputs.repository }}
+        direction: first
+        nth: 0
     - name: generate comment body
       id: body
       shell: bash
       run: |
+        echo "::notice:: found ${{ steps.search.outputs.comment-id }} on issue ${{ inputs.issue_number || github.event.issue.number }}"
         comment_body_file=$(mktemp --tmpdir="$RUNNER_TEMP" "pr-comment-XXXXXXXX")
         echo "comment_body_file=$comment_body_file" >> "$GITHUB_OUTPUT"
         {
@@ -57,10 +60,10 @@ runs:
             printf '%s' "${{ inputs.body }}"
           fi
           printf '\n%s\n' "<!-- ${{ inputs.search_term }} -->"
-        } >> $comment_body_file
+        } >> "$comment_body_file"
     - name: Write Comment
       id: comment
-      uses: peter-evans/create-or-update-comment@v3.0.2
+      uses: peter-evans/create-or-update-comment@v3.1.0
       with:
         token: ${{ inputs.token }}
         repository: ${{ inputs.repository}}


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

interlok-build-parent comments on PRs using `actions/github-script` we can probably do something cleverer than that

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
add action based on peter-evans/find-comment & create-or-update
add test that refers to self-same PR to comment on.
<!-- SQUASH_MERGE_END -->

