### PR TITLE
feat: add load_locally input to docker-image-builder

### DIFF
--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -36,6 +36,7 @@ jobs:
         uses: ./docker-image-builder
         with:
           registry_push: false
+          load_locally: true
           dockerfile: docker-image-builder/Dockerfile.test
           image_platforms: linux/amd64
           dockerhub_image_name: ${{ github.repository_owner }}/test-docker-image-builder
@@ -46,3 +47,9 @@ jobs:
           docker run --rm \
             --entrypoint=bash ${{ github.repository_owner }}/test-docker-image-builder:latest \
             -c "curl -fSsL https://raw.githubusercontent.com/${{ github.repository }}/main/README.md"
+      - name: Cleanup
+        # Our work here is done, so cleanup
+        id: cleanup
+        if: success() || failure()
+        run: |
+          docker rmi ${{ github.repository_owner }}/test-docker-image-builder:latest

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Whether to push to the registry
     required: false
     default: "false"
+  load_locally:
+    description: Whether to load the image locally if you want to use it in a later step
+    required: false
+    default: "false"
   dockerfile:
     description: Path to the dockerfile
     required: true
@@ -86,7 +90,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         platforms: ${{ inputs.image_platforms }}
         push: ${{ inputs.registry_push }}
-        load: ${{ inputs.registry_push == 'false' }}
+        load: ${{ inputs.load_locally }}
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
         provenance: false


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

If `registry_push` == false then the image that we built is loaded into the local environment which is great for testing purposes (otherwise the image isn't available to use via `docker run`)

However, it's not so good if you're building an image that's ostensibly private since it may not be cleaned up by the runner itself.

Add an explicitly `load_locally` input that can be set (true|false, defaults false) so that you can choose to do it.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
add 'load_locally' input param
<!-- SQUASH_MERGE_END -->

