### PR TITLE
fix: add a pull_request docker tag on pull requests

### DIFF
--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -2,6 +2,8 @@ name: test-docker-image-builder
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "docker-image-builder/**"
       - ".github/workflows/test-docker-image-builder.yml"
@@ -44,12 +46,14 @@ jobs:
         id: docker_run
         # bash + curl installed as part of docker-image-builder/Dockerfile.test
         run: |
-          docker run --rm \
-            --entrypoint=bash ${{ github.repository_owner }}/test-docker-image-builder:latest \
+          test_image=$(echo "${{ steps.docker.outputs.image_tags }}" | head -n 1 | cut -d' ' -f1)
+          docker run --rm --entrypoint=bash "$test_image" \
             -c "curl -fSsL https://raw.githubusercontent.com/${{ github.repository }}/main/README.md"
       - name: Cleanup
         # Our work here is done, so cleanup
         id: cleanup
         if: success() || failure()
         run: |
-          docker rmi ${{ github.repository_owner }}/test-docker-image-builder:latest
+          for image in "${{ steps.docker.outputs.image_tags }}"; do
+            docker rmi "$image"
+          done

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -42,18 +42,46 @@ jobs:
           dockerfile: docker-image-builder/Dockerfile.test
           image_platforms: linux/amd64
           dockerhub_image_name: ${{ github.repository_owner }}/test-docker-image-builder
+      - name: check outputs
+        id: check_outputs
+        env:
+          DOCKER_LABELS: ${{ steps.docker.outputs.labels }}
+          DOCKER_JSON: ${{ steps.docker.outputs.json }}
+          DOCKER_TAGS: ${{ steps.docker.outputs.image_tags }}
+          DOCKER_VERSION: ${{ steps.docker.outputs.version }}
+        run: |
+          if [[ -z "$DOCKER_TAGS" ]]; then
+            echo "::error::image_tags not set by docker-image-builder"
+            exit 1
+          fi
+          if [[ -z "$DOCKER_LABELS" ]]; then
+            echo "::error::labels not set by docker-image-builder"
+            exit 1
+          fi
+          if [[ -z "$DOCKER_VERSION" ]]; then
+            echo "::error::version not set by docker-image-builder"
+            exit 1
+          fi
+          if [[ -z "$DOCKER_JSON" ]]; then
+            echo "::error::json not set by docker-image-builder"
+            exit 1
+          fi
       - name: Use the image
         id: docker_run
         # bash + curl installed as part of docker-image-builder/Dockerfile.test
+        env:
+          DOCKER_TAGS: ${{ steps.docker.outputs.image_tags }}
         run: |
-          test_image=$(echo "${{ steps.docker.outputs.image_tags }}" | head -n 1 | cut -d' ' -f1)
+          test_image=$(echo "$DOCKER_TAGS" | head -n 1 | cut -d' ' -f1)
           docker run --rm --entrypoint=bash "$test_image" \
             -c "curl -fSsL https://raw.githubusercontent.com/${{ github.repository }}/main/README.md"
       - name: Cleanup
         # Our work here is done, so cleanup
         id: cleanup
         if: success() || failure()
+        env:
+          DOCKER_TAGS: ${{ steps.docker.outputs.image_tags }}
         run: |
-          for image in "${{ steps.docker.outputs.image_tags }}"; do
+          for image in "$DOCKER_TAGS"; do
             docker rmi "$image"
           done

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -38,6 +38,19 @@ inputs:
   dockerhub_token:
     description: Dockerhub token
     required: false
+outputs:
+  image_tags:
+    description: Docker tags
+    value: ${{ steps.docker_meta.outputs.tags }}
+  labels:
+    description: Docker labels
+    value: ${{ steps.docker_meta.outputs.labels }}
+  version:
+    description: Docker image version
+    value: ${{ steps.docker_meta.outputs.version }}
+  json:
+    description: JSON output of tags and labels
+    value: ${{ steps.docker_meta.outputs.json }}
 
 runs:
   using: composite
@@ -80,6 +93,7 @@ runs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
+          type=ref,event=pr,priority=100
           type=raw,value=latest,enable={{is_default_branch}}
     - name: Build Image
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Resolves #12 

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add outputs to action (all from docker/metadata-action) with explicit tests
- modify test to only fire on PR or push to main
push to main -> tag_version == latest
pr -> tag_version == pr-[0-9]+
- cope with possible multiple tags emitted by metadata-action
<!-- SQUASH_MERGE_END -->

