### PR TITLE
feat: add commit-status-and-label action

### DIFF
--- a/.github/workflows/test-commit-status.yml
+++ b/.github/workflows/test-commit-status.yml
@@ -1,0 +1,67 @@
+name: test-commit-status
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "commit-status-and-label/**"
+      - ".github/workflows/test-commit-status.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "commit-status-and-label/**"
+      - ".github/workflows/test-commit-status.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test-commit-status:
+    name: test-commit-status
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Update Status
+        id: test_commit_status_update
+        uses: ./commit-status-and-label
+        with:
+          token: ${{ github.token }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "pending"
+          context: "test-commit-status"
+      - name: Check Status
+        id: check
+        uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
+        with:
+          script: |
+            response = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/status', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}',
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            })
+            const status=response.data.statuses.filter((status) => status.context === 'test-commit-status' && status.state === 'pending');
+            if (status.length < 1) {
+              throw new Error('Expected at least one status to be pending');
+            }
+      - name: Update Status
+        id: update_commit_status
+        uses: ./commit-status-and-label
+        with:
+          token: ${{ github.token }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "success"
+          context: "test-commit-status"

--- a/.github/workflows/test-commit-status.yml
+++ b/.github/workflows/test-commit-status.yml
@@ -40,7 +40,7 @@ jobs:
           sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
           state: "pending"
           context: "test-commit-status"
-          label_prefix: "unit_tests"
+          label_prefix: "commit_status_tests: "
       - name: Check Status
         id: check
         uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
@@ -67,4 +67,4 @@ jobs:
           sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
           state: ${{ steps.check.outcome }}
           context: "test-commit-status"
-          label_prefix: "unit_tests"
+          label_prefix: "commit_status_tests: "

--- a/.github/workflows/test-commit-status.yml
+++ b/.github/workflows/test-commit-status.yml
@@ -40,6 +40,7 @@ jobs:
           sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
           state: "pending"
           context: "test-commit-status"
+          label_prefix: "unit_tests"
       - name: Check Status
         id: check
         uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
@@ -59,9 +60,11 @@ jobs:
             }
       - name: Update Status
         id: update_commit_status
+        if: success() || failure()
         uses: ./commit-status-and-label
         with:
           token: ${{ github.token }}
           sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
-          state: "success"
+          state: ${{ steps.check.outcome }}
           context: "test-commit-status"
+          label_prefix: "unit_tests"

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -25,7 +25,10 @@ jobs:
     name: test-docker-image-builder
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     steps:
       - name: step-security/harden-runner
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
@@ -33,6 +36,13 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Pending Status
+        id: pending
+        uses: ./commit-status-and-label
+        with:
+          token: ${{ github.token }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "pending"
       - name: docker-image-builder
         id: docker
         uses: ./docker-image-builder
@@ -79,9 +89,17 @@ jobs:
         # Our work here is done, so cleanup
         id: cleanup
         if: success() || failure()
+        continue-on-error: true
         env:
           DOCKER_TAGS: ${{ steps.docker.outputs.image_tags }}
         run: |
           for image in "$DOCKER_TAGS"; do
             docker rmi "$image"
           done
+      - name: Update Status
+        id: update
+        uses: ./commit-status-and-label
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "${{ steps.docker_run.outcome }}"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ The source of the actions themselves are of course self-documenting :roll_eyes: 
 - [repo-dispatch](./repo-dispatch/README.md)
 - [generate-dependabot-config](./generate-dependabot-config/README.md)
 - [pr-or-issue-comment](./pr-or-issue-comment/README.md)
+- [commit-status-and-label](./commit-status-and-label/README.md)

--- a/commit-status-and-label/README.md
+++ b/commit-status-and-label/README.md
@@ -8,7 +8,7 @@ In this specific repository; how do you enable required checks (via branch prote
 
 ## Usage
 
-- Requires you to have at least `statuses:write`, `pull_requests:write` and probably `contents:write` permissions attached to the token.
+- Requires you to have at least `statuses:write`, `issues:write`, `pull_requests:write` and probably `contents:write` permissions attached to the token.
 
 ```action
 - name: Pending Status
@@ -38,12 +38,15 @@ In this specific repository; how do you enable required checks (via branch prote
 
 ## Notes
 
+- Of course it's up to you to assign pretty colours to your labels.
 - There is a potential timing issue if you have multiple triggered workflows that all use the same _context_ for the commit status. Not entirely sure what happens vis-a-vis branch protection rules there.
 - In the example above I'm passing in the 'outcome' from the tests job which might actually be 'success | failure | skipped | cancelled'. Success and failure are self-evidently supported; skipped & cancelled are taken to be 'error'.
+- There's use of `actions/github-script`; I was going to use `gh` but I had permissions issues and though I don't enjoy doing javascript, I do know enough to get into trouble. In this instance I would have much preferred to use `bash` everywhere.
 
 ## Dependencies
 
 It's a composite action that wraps the following actions:
 
-- peter-evans/find-comment
-- peter-evans/create-or-update-comment
+- jwalton/gh-find-current-pr
+- actions/github-script
+- octodemo-resources/github-commit-status (but this could easily be actions/github-script again).

--- a/commit-status-and-label/README.md
+++ b/commit-status-and-label/README.md
@@ -8,7 +8,8 @@ In this specific repository; how do you enable required checks (via branch prote
 
 ## Usage
 
-- Requires you to have at least `statuses:write`, `issues:write`, `pull_requests:write` and probably `contents:write` permissions attached to the token.
+- Requires you to have at least `statuses:write`, `pull_requests:write` and perhaps `issues:write`, + `contents:write` permissions attached to the token.
+
 
 ```action
 - name: Pending Status
@@ -19,7 +20,7 @@ In this specific repository; how do you enable required checks (via branch prote
     sha: ${{ github.event.pull_request.head.sha }}
     state: "pending"
     # context: "Check"
-    # prefix: "check"
+    # prefix: "check_"
 - name: Do the tests
   id: tests
   run: |
@@ -33,14 +34,16 @@ In this specific repository; how do you enable required checks (via branch prote
     sha: ${{ github.event.pull_request.head.sha }}
     state: ${{ steps.tests.outcome }}
     # context: "Check"
-    # prefix: "check"
+    # prefix: "check_"
 ```
 
 ## Notes
 
 - Of course it's up to you to assign pretty colours to your labels.
+- According to the documentation you may only add 1k states to a given commit sha. Bear that in mind if you're basically adding a commit status to the same SHA over and over.
 - There is a potential timing issue if you have multiple triggered workflows that all use the same _context_ for the commit status. Not entirely sure what happens vis-a-vis branch protection rules there.
-- In the example above I'm passing in the 'outcome' from the tests job which might actually be 'success | failure | skipped | cancelled'. Success and failure are self-evidently supported; skipped & cancelled are taken to be 'error'.
+  - This will happen in this project because of dependabot updating _all of the test-*.yml_ with an update to `actions/checkout` which will then trigger 3x builds; they'll all use the same context `Check` for the given commit SHA, so we'll see what happens.
+- In the example above I'm passing in the 'outcome' from the tests job which is actually 'success | failure | skipped | cancelled'. Success and failure are valid commit statuses; skipped & cancelled are mapped to be 'error'.
 - There's use of `actions/github-script`; I was going to use `gh` but I had permissions issues and though I don't enjoy doing javascript, I do know enough to get into trouble. In this instance I would have much preferred to use `bash` everywhere.
 
 ## Dependencies
@@ -49,4 +52,4 @@ It's a composite action that wraps the following actions:
 
 - jwalton/gh-find-current-pr
 - actions/github-script
-- octodemo-resources/github-commit-status (but this could easily be actions/github-script again).
+- (octodemo-resources/github-commit-status) - I'm unsure as to whether to trust something called octodemo-resources so it's a github-script.

--- a/commit-status-and-label/README.md
+++ b/commit-status-and-label/README.md
@@ -1,0 +1,49 @@
+# commit-status-and-label
+
+Updates a commit associated with a SHA with a commit status. If there is an associated PR with that commit then add a label to the PR that reflects the commit status
+
+## Why
+
+In this specific repository; how do you enable required checks (via branch protection) when you don't know _all the possible workflows_ that might run (i.e. if `docker-image-builder/*` doesn't change we won't run `test-docker-image-builder.yml`). This allows us to add a commit status; which then means that the 'context' can be marked as a required check in the branch protection rules.
+
+## Usage
+
+- Requires you to have at least `statuses:write`, `pull_requests:write` and probably `contents:write` permissions attached to the token.
+
+```action
+- name: Pending Status
+  id: pending
+  uses: quotdian-ennui/actions-olio/commit-status-and-label@main
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    sha: ${{ github.event.pull_request.head.sha }}
+    state: "pending"
+    # context: "Check"
+    # prefix: "check"
+- name: Do the tests
+  id: tests
+  run: |
+    echo "Doing the tests"
+- name: Update Status
+  id: pending
+  uses: quotdian-ennui/actions-olio/commit-status-and-label@main
+  if: success() || failure()
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    sha: ${{ github.event.pull_request.head.sha }}
+    state: ${{ steps.tests.outcome }}
+    # context: "Check"
+    # prefix: "check"
+```
+
+## Notes
+
+- There is a potential timing issue if you have multiple triggered workflows that all use the same _context_ for the commit status. Not entirely sure what happens vis-a-vis branch protection rules there.
+- In the example above I'm passing in the 'outcome' from the tests job which might actually be 'success | failure | skipped | cancelled'. Success and failure are self-evidently supported; skipped & cancelled are taken to be 'error'.
+
+## Dependencies
+
+It's a composite action that wraps the following actions:
+
+- peter-evans/find-comment
+- peter-evans/create-or-update-comment

--- a/commit-status-and-label/action.yml
+++ b/commit-status-and-label/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
 
     - name: Find associated PR
-      uses: jwalton/gh-find-current-pr@v1.3.2
+      uses: jwalton/gh-find-current-pr@7ada613939e2a233c83a1320679446fa1c6bdcb9 # v1.3.2
       id: findpr
       if: |
         inputs.pull_request == ''
@@ -62,7 +62,7 @@ runs:
         echo "status_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
 
     - name: Update PR Label
-      uses: actions/github-script@v7.0.0
+      uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
       if: |
         steps.bootstrap.outputs.pr_number != ''
       with:
@@ -86,7 +86,7 @@ runs:
 
     - name: Create Commit Status
       id: commit_status
-      uses: octodemo-resources/github-commit-status@v1.0.0
+      uses: octodemo-resources/github-commit-status@fa054ae3db24c384f8806bd990cc28ff1606fd5b # v1.0.0
       with:
         repository: ${{ github.repository }}
         sha: ${{ inputs.sha }}
@@ -95,10 +95,9 @@ runs:
         description: "${{ steps.bootstrap.outputs.short_desc }}"
         target_url: "${{ steps.bootstrap.outputs.status_url }}"
         token: ${{ inputs.token }}
-
     # Could use github-script
     # - name: Workflow Failure
-    #   uses: actions/github-script@v7.0.0
+    #   uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
     #   with:
     #     script: |
     #       github.rest.repos.createCommitStatus({

--- a/commit-status-and-label/action.yml
+++ b/commit-status-and-label/action.yml
@@ -3,26 +3,26 @@ description: |
   Add a commit status to a SHA and label the associated open PR (if there is one) accordingly
 inputs:
   sha:
-    description: 'The commit SHA'
+    description: "The commit SHA"
     required: true
   state:
-    description: 'The state for the commit status (error | pending | failure | success)'
+    description: "The state for the commit status (error | pending | failure | success)"
     required: true
   pull_request:
     description: "The pull request number, if not specified we'll try to find it based on the commit SHA"
     required: false
   token:
-    description: 'The GitHub token to use for authentication.'
+    description: "The GitHub token to use for authentication."
     required: false
     default: '${{ github.token }}'
   context:
-    description: 'The context for the commit status (default: Check)'
+    description: "The context for the commit status (default: Check)"
     required: false
     default: 'Check'
   label_prefix:
-    description: 'The prefix for the label (default: check)'
+    description: "The prefix for the label (adds a label if set, default is 'check_')"
     required: false
-    default: 'check'
+    default: 'check_'
 
 runs:
   using: composite
@@ -56,7 +56,7 @@ runs:
         state=$(sense_check "${{ inputs.state }}")
         # shellcheck disable=SC2129
         echo "state=$state" >> "$GITHUB_OUTPUT"
-        echo "label=${{ inputs.label_prefix }}_$state" >> "$GITHUB_OUTPUT"
+        echo "label=${{ inputs.label_prefix }}$state" >> "$GITHUB_OUTPUT"
         echo "pr_number=${{ steps.findpr.outputs.pr || inputs.pull_request }}" >> "$GITHUB_OUTPUT"
         echo "short_desc=${{ inputs.context }} $state" >> "$GITHUB_OUTPUT"
         echo "status_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
@@ -64,7 +64,8 @@ runs:
     - name: Update PR Label
       uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
       if: |
-        steps.bootstrap.outputs.pr_number != ''
+        steps.bootstrap.outputs.pr_number != '' &&
+        inputs.label_prefix != ''
       with:
         script: |
           response = await github.rest.issues.listLabelsOnIssue({
@@ -74,7 +75,7 @@ runs:
             });
           const existingLabels = response.data.map((label) => label.name)
           const newLabels = existingLabels.filter(
-            (l) => !l.startsWith('${{ inputs.label_prefix }}_')
+            (l) => !l.startsWith('${{ inputs.label_prefix }}')
           );
           newLabels.push('${{ steps.bootstrap.outputs.label }}');
           await github.rest.issues.setLabels({
@@ -84,28 +85,28 @@ runs:
             labels: newLabels
           })
 
-    - name: Create Commit Status
-      id: commit_status
-      uses: octodemo-resources/github-commit-status@fa054ae3db24c384f8806bd990cc28ff1606fd5b # v1.0.0
+    - name: Workflow Failure
+      uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
       with:
-        repository: ${{ github.repository }}
-        sha: ${{ inputs.sha }}
-        context: ${{ inputs.context }}
-        state: ${{ steps.bootstrap.outputs.state }}
-        description: "${{ steps.bootstrap.outputs.short_desc }}"
-        target_url: "${{ steps.bootstrap.outputs.status_url }}"
-        token: ${{ inputs.token }}
-    # Could use github-script
-    # - name: Workflow Failure
-    #   uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
+        script: |
+          github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: "${{ inputs.sha }}",
+            target_url: "${{ steps.bootstrap.outputs.status_url }}",
+            state: "${{ steps.bootstrap.outputs.state }}",
+            description: "${{ steps.bootstrap.outputs.short_desc }}",
+            context: "${{ inputs.context }}"
+          })
+    # does relying on something called octodemo-resources make sense?
+    # - name: Create Commit Status
+    #   id: commit_status
+    #   uses: octodemo-resources/github-commit-status@fa054ae3db24c384f8806bd990cc28ff1606fd5b # v1.0.0
     #   with:
-    #     script: |
-    #       github.rest.repos.createCommitStatus({
-    #         owner: context.repo.owner,
-    #         repo: context.repo.repo,
-    #         sha: "${{ inputs.sha }}",
-    #         target_url: "${{ steps.bootstrap.outputs.status_url }}",
-    #         state: "${{ steps.bootstrap.outputs.state }}",
-    #         description: "${{ steps.bootstrap.outputs.short_desc }}",
-    #         context: "${{ inputs.context }}"
-    #       })
+    #     repository: ${{ github.repository }}
+    #     sha: ${{ inputs.sha }}
+    #     context: ${{ inputs.context }}
+    #     state: ${{ steps.bootstrap.outputs.state }}
+    #     description: "${{ steps.bootstrap.outputs.short_desc }}"
+    #     target_url: "${{ steps.bootstrap.outputs.status_url }}"
+    #     token: ${{ inputs.token }}

--- a/commit-status-and-label/action.yml
+++ b/commit-status-and-label/action.yml
@@ -27,6 +27,17 @@ inputs:
 runs:
   using: composite
   steps:
+
+    - name: Find associated PR
+      uses: jwalton/gh-find-current-pr@v1.3.2
+      id: findpr
+      if: |
+        inputs.pull_request == ''
+      with:
+        github-token: ${{ inputs.token }}
+        state: open
+        sha: ${{ inputs.sha }}
+
     - name: bootstrap
       id: bootstrap
       shell: bash
@@ -46,25 +57,18 @@ runs:
         # shellcheck disable=SC2129
         echo "state=$state" >> "$GITHUB_OUTPUT"
         echo "label=${{ inputs.label_prefix }}_$state" >> "$GITHUB_OUTPUT"
+        echo "pr_number=${{ steps.findpr.outputs.pr || inputs.pull_request }}" >> "$GITHUB_OUTPUT"
         echo "short_desc=${{ inputs.context }} $state" >> "$GITHUB_OUTPUT"
         echo "status_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
 
-    - name: Find associated PR
-      uses: jwalton/gh-find-current-pr@v1.3.2
-      id: findpr
-      if: |
-        inputs.pull_request == ''
-      with:
-        github-token: ${{ inputs.token }}
-        state: open
-        sha: ${{ inputs.sha }}
-
     - name: Update PR Label
       uses: actions/github-script@v7.0.0
+      if: |
+        steps.bootstrap.outputs.pr_number != ''
       with:
         script: |
           response = await github.rest.issues.listLabelsOnIssue({
-              issue_number: ${{ steps.findpr.outputs.pr || inputs.pull_request }},
+              issue_number: ${{ steps.bootstrap.outputs.pr_number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
@@ -74,7 +78,7 @@ runs:
           );
           newLabels.push('${{ steps.bootstrap.outputs.label }}');
           await github.rest.issues.setLabels({
-            issue_number: ${{ steps.findpr.outputs.pr || inputs.pull_request }},
+            issue_number: ${{ steps.bootstrap.outputs.pr_number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
             labels: newLabels

--- a/commit-status-and-label/action.yml
+++ b/commit-status-and-label/action.yml
@@ -1,0 +1,108 @@
+name: Add a commit status & label a PR
+description: |
+  Add a commit status to a SHA and label the associated open PR (if there is one) accordingly
+inputs:
+  sha:
+    description: 'The commit SHA'
+    required: true
+  state:
+    description: 'The state for the commit status (error | pending | failure | success)'
+    required: true
+  pull_request:
+    description: "The pull request number, if not specified we'll try to find it based on the commit SHA"
+    required: false
+  token:
+    description: 'The GitHub token to use for authentication.'
+    required: false
+    default: '${{ github.token }}'
+  context:
+    description: 'The context for the commit status (default: Check)'
+    required: false
+    default: 'Check'
+  label_prefix:
+    description: 'The prefix for the label (default: check)'
+    required: false
+    default: 'check'
+
+runs:
+  using: composite
+  steps:
+    - name: bootstrap
+      id: bootstrap
+      shell: bash
+      run: |
+        function sense_check() {
+          local state=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+          case "$state" in
+            error|pending|failure|success)
+              echo "$state"
+              ;;
+            *)
+              echo "error"
+              ;;
+          esac
+        }
+        state=$(sense_check "${{ inputs.state }}")
+        # shellcheck disable=SC2129
+        echo "state=$state" >> "$GITHUB_OUTPUT"
+        echo "label=${{ inputs.label_prefix }}_$state" >> "$GITHUB_OUTPUT"
+        echo "short_desc=${{ inputs.context }} $state" >> "$GITHUB_OUTPUT"
+        echo "status_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+    - name: Find associated PR
+      uses: jwalton/gh-find-current-pr@v1.3.2
+      id: findpr
+      if: |
+        inputs.pull_request == ''
+      with:
+        github-token: ${{ inputs.token }}
+        state: open
+        sha: ${{ inputs.sha }}
+
+    - name: Update PR Label
+      uses: actions/github-script@v7.0.0
+      with:
+        script: |
+          response = await github.rest.issues.listLabelsOnIssue({
+              issue_number: ${{ steps.findpr.outputs.pr || inputs.pull_request }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+          const existingLabels = response.data.map((label) => label.name)
+          const newLabels = existingLabels.filter(
+            (l) => !l.startsWith('${{ inputs.label_prefix }}_')
+          );
+          newLabels.push('${{ steps.bootstrap.outputs.label }}');
+          await github.rest.issues.setLabels({
+            issue_number: ${{ steps.findpr.outputs.pr || inputs.pull_request }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: newLabels
+          })
+
+    - name: Create Commit Status
+      id: commit_status
+      uses: octodemo-resources/github-commit-status@v1.0.0
+      with:
+        repository: ${{ github.repository }}
+        sha: ${{ inputs.sha }}
+        context: ${{ inputs.context }}
+        state: ${{ steps.bootstrap.outputs.state }}
+        description: "${{ steps.bootstrap.outputs.short_desc }}"
+        target_url: "${{ steps.bootstrap.outputs.status_url }}"
+        token: ${{ inputs.token }}
+
+    # Could use github-script
+    # - name: Workflow Failure
+    #   uses: actions/github-script@v7.0.0
+    #   with:
+    #     script: |
+    #       github.rest.repos.createCommitStatus({
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         sha: "${{ inputs.sha }}",
+    #         target_url: "${{ steps.bootstrap.outputs.status_url }}",
+    #         state: "${{ steps.bootstrap.outputs.state }}",
+    #         description: "${{ steps.bootstrap.outputs.short_desc }}",
+    #         context: "${{ inputs.context }}"
+    #       })


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

In this specific repository; how do you enable required checks (via branch protection) when you don't know _all the possible workflows_ that might run (i.e. if `docker-image-builder/*` doesn't change we won't run `test-docker-image-builder.yml`). This allows us to add a commit status; which then means that the 'context' can be marked as a required check in the branch protection rules.

> should be able to test more formally via interlok-build-parent which does a commit-status & label as part of its dependabot shenanigans

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add action to add commit status & label a PR
- add explicit test-commit-status
- integration test via test-docker-image-builder
<!-- SQUASH_MERGE_END -->

