### PR TITLE
feat: add use of commit-status-and-label

### DIFF
--- a/.github/workflows/test-commenter.yml
+++ b/.github/workflows/test-commenter.yml
@@ -2,6 +2,14 @@ name: test-commenter
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - "pr-or-issue-comment/**"
+      - ".github/workflows/test-commenter.yml"
+  pull_request:
+    branches:
+      - main
     paths:
       - "pr-or-issue-comment/**"
       - ".github/workflows/test-commenter.yml"
@@ -20,13 +28,22 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Update Status
+        id: check_pending
+        uses: ./commit-status-and-label
+        if: github.event_name == 'pull_request'
+        with:
+          token: ${{ github.token }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "pending"
       - name: generate comment
         id: generate
         run: |
-          echo "comment=$(date -u +"%Y-%m-%d %H:%M:%S") via [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "$GITHUB_OUTPUT"
+          echo "comment=${{ github.event_name }}(${{ github.ref }}) on $(date -u +"%Y-%m-%d %H:%M:%S") via [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "$GITHUB_OUTPUT"
       - name: comment
         id: comment_default_search
         uses: ./pr-or-issue-comment
@@ -55,3 +72,13 @@ jobs:
             echo "::error::comment-id not set by comment_search"
             exit 1
           fi
+      - name: Check Status
+        id: check_outcome
+        uses: ./commit-status-and-label
+        if: |
+          (success() || failure()) &&
+          github.event_name == 'pull_request'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "${{ steps.assert.outcome }}"

--- a/.github/workflows/test-commit-status.yml
+++ b/.github/workflows/test-commit-status.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Update Status
+        id: check_pending
+        uses: ./commit-status-and-label
+        if: github.event_name == 'pull_request'
+        with:
+          token: ${{ github.token }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "pending"
+      - name: Update Status
         id: test_commit_status_update
         uses: ./commit-status-and-label
         with:
@@ -68,3 +76,13 @@ jobs:
           state: ${{ steps.check.outcome }}
           context: "test-commit-status"
           label_prefix: "commit_status_tests: "
+      - name: Check Status
+        id: check_outcome
+        uses: ./commit-status-and-label
+        if: |
+          (success() || failure()) &&
+          github.event_name == 'pull_request'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          state: "${{ steps.check.outcome }}"

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -36,9 +36,10 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Pending Status
-        id: pending
+      - name: Update Status
+        id: check_pending
         uses: ./commit-status-and-label
+        if: github.event_name == 'pull_request'
         with:
           token: ${{ github.token }}
           sha:  ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
@@ -96,8 +97,11 @@ jobs:
           for image in "$DOCKER_TAGS"; do
             docker rmi "$image"
           done
-      - name: Update Status
-        id: update
+      - name: Check Status
+        id: check_outcome
+        if: |
+          (success() || failure()) &&
+          github.event_name == 'pull_request'
         uses: ./commit-status-and-label
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/commit-status-and-label/README.md
+++ b/commit-status-and-label/README.md
@@ -41,8 +41,8 @@ In this specific repository; how do you enable required checks (via branch prote
 
 - Of course it's up to you to assign pretty colours to your labels.
 - According to the documentation you may only add 1k states to a given commit sha. Bear that in mind if you're basically adding a commit status to the same SHA over and over.
-- There is a potential timing issue if you have multiple triggered workflows that all use the same _context_ for the commit status. Not entirely sure what happens vis-a-vis branch protection rules there.
-  - This will happen in this project because of dependabot updating _all of the test-*.yml_ with an update to `actions/checkout` which will then trigger 3x builds; they'll all use the same context `Check` for the given commit SHA, so we'll see what happens.
+- There is a timing issue if you have multiple triggered workflows that all use the same _context_ for the commit status. The context will transition to _success_ before all the actual checks have executed. You don't want to have automerge enabled if that's the case.
+  - It happens in this project; if dependabot 'updates `actions/checkout`' then the 3 test- workflows that trigger on a PR will all update the same 'check' context. 'test-docker-image.yml' will always take the longest but the commit status has transitioned to `success` before it finishes.
 - In the example above I'm passing in the 'outcome' from the tests job which is actually 'success | failure | skipped | cancelled'. Success and failure are valid commit statuses; skipped & cancelled are mapped to be 'error'.
 - There's use of `actions/github-script`; I was going to use `gh` but I had permissions issues and though I don't enjoy doing javascript, I do know enough to get into trouble. In this instance I would have much preferred to use `bash` everywhere.
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

It's time to drink our own champagne.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- added use of commit-status to every test workflow.
<!-- SQUASH_MERGE_END -->

