### PR TITLE
feat(ci): add static analysis workflow

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       actions: ${{ steps.changes.outputs.actions_any_changed }}
       workflows: ${{ steps.changes.outputs.workflows_any_changed }}
+      shellscripts: ${{ steps.changes.outputs.shellscripts_any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -36,6 +37,8 @@ jobs:
               - "**/action.yml"
             workflows:
               - ".github/workflows/**"
+            shellscripts:
+              - "**/*.sh"
 
   commits:
     name: Conventional Commits
@@ -75,3 +78,24 @@ jobs:
           fail_on_error: true
           tool_name: actionlint
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.event_name == 'pull_request' &&  needs.changes.outputs.shellscripts == 'true'
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@96fa305c16b0f9cc9b093af22dcd09de1c8f1c2d # v1.19.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          pattern: |
+            *.sh

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,0 +1,77 @@
+name: Static Analysis
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      actions: ${{ steps.changes.outputs.actions_any_changed }}
+      workflows: ${{ steps.changes.outputs.workflows_any_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+          # fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+      - name: Changed Files
+        # Attempt to figure out what files have changed
+        id: changes
+        uses: tj-actions/changed-files@25ef3926d147cd02fc7e931c1ef50772bbb0d25d # v40.1.1
+        with:
+          files_yaml: |
+            actions:
+              - "**/action.yml"
+            workflows:
+              - ".github/workflows/**"
+
+  commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: committed
+        uses: crate-ci/committed@e0a4ba358ac0e6292e750f61b74f77a347eb10ad # v1.0.20
+        with:
+          args: --no-merge-commit
+
+  # actionlint as of 1.6.26 only supports workflows (not resuable actions)
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      github.event_name == 'pull_request' &&  needs.changes.outputs.workflows == 'true'
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: actionlint
+        uses: reviewdog/action-actionlint@82693e9e3b239f213108d6e412506f8b54003586 # v1.39.1
+        with:
+          reporter: github-pr-review
+          fail_on_error: true
+          tool_name: actionlint
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Adds some static analysis tooling.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add crates-ci/committed check
- add reviewdog/action-actionlint
- add reviewdog/action-shellcheck (bit premature)
<!-- SQUASH_MERGE_END -->

