### PR TITLE
refactor(ci): allow merge of patch with no tests

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -18,9 +18,11 @@ jobs:
     permissions:
       contents: read
     outputs:
-      actions: ${{ steps.changes.outputs.actions_any_changed }}
       workflows: ${{ steps.changes.outputs.workflows_any_changed }}
       shellscripts: ${{ steps.changes.outputs.shellscripts_any_changed }}
+      dependabot_merge: ${{ steps.changes.outputs.dependabot_merge_any_changed }}
+      dependabot_config: ${{ steps.changes.outputs.dependabot_config_any_changed }}
+      default_updatecli: ${{ steps.changes.outputs.default_updatecli_any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -33,12 +35,17 @@ jobs:
         uses: tj-actions/changed-files@800a2825992141ddde1a8bca8ad394cec34d3188 # v42.0.5
         with:
           files_yaml: |
-            actions:
-              - "**/action.yml"
             workflows:
               - ".github/workflows/**"
             shellscripts:
               - "**/*.sh"
+            dependabot_merge:
+              - "dependabot-merge/**"
+            dependabot_config:
+              - "generate-dependabot-config/**"
+            default_updatecli:
+              - "default-updatecli/**"
+
 
   commits:
     name: Conventional Commits
@@ -99,3 +106,25 @@ jobs:
           reporter: github-pr-review
           pattern: |
             *.sh
+
+  dependabot_patch_merge:
+    name: merge-untested-actions
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    permissions:
+      contents: write
+    if: |
+      (needs.changes.outputs.dependabot_merge == 'true' ||
+      needs.changes.outputs.dependabot_config == 'true' ||
+      needs.changes.outputs.default_updatecli == 'true') &&
+      github.event_name == 'pull_request' &&
+      github.actor == 'dependabot[bot]'
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: dispatch
+        uses: ./pr-trigger
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event_type: "pr-untested-actions"

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -45,6 +45,10 @@ jobs:
               echo 'change_filter=repo-dispatch/**' >> "$GITHUB_OUTPUT"
               echo 'automerge_level=semver-patch' >> "$GITHUB_OUTPUT"
               ;;
+            pr-untested-actions)
+              echo 'change_filter=dependabot-merge/**,default-updatecli/**,generate-dependabot-config/**' >> "$GITHUB_OUTPUT"
+              echo 'automerge_level=semver-patch' >> "$GITHUB_OUTPUT"
+              ;;
             *)
               echo 'change_filter=.github/workflows/**' >> "$GITHUB_OUTPUT"
               echo 'automerge_level=semver-patch|semver-minor' >> "$GITHUB_OUTPUT"
@@ -65,3 +69,4 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           automerge_level: ${{ steps.prepare.outputs.automerge_level }}
           change_filter: ${{ steps.prepare.outputs.change_filter }}
+          filter_separator: ","

--- a/dependabot-merge/action.yml
+++ b/dependabot-merge/action.yml
@@ -10,9 +10,14 @@ inputs:
     default: ${{ github.token }}
   change_filter:
     description: |
-      The filter to use finding source file changes
+      The filter to use finding source file changes.
     required: false
     default: ".github/workflows/**"
+  filter_separator:
+    description: |
+      The separator to use when splitting the change_filter.
+    required: false
+    default: "\n"
   automerge_level:
     description: |
       The semver level to allow automerge up to (default semver-patch|semver-minor).
@@ -26,6 +31,7 @@ runs:
       uses: tj-actions/changed-files@3f54ebb830831fc121d3263c1857cfbdc310cdb9 # v42.0.4
       with:
         files: ${{ inputs.change_filter }}
+        files_separator: ${{ inputs.filter_separator }}
     - name: Prepare
       id: bootstrap
       shell: bash


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Resolves #68

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- Introduce a new filter_separator input param to dependabot-merge
- analyze workflow now generates a 'pr-untested-actions" dispatch
- dependabot-merge now handles pr-untested-actions with using comma
as the filter separator
<!-- SQUASH_MERGE_END -->

