### PR TITLE
feat(docker-image-builder): add automatic caching capability

### DIFF
--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        docker_target: ["explict-cache", "nocache", "autocache"]
+        docker_target: ["explict-cache", "nocache", "autocache", "local-cache"]
         include:
           - docker_target: explict-cache
             docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-cache
@@ -41,12 +41,17 @@ jobs:
             cache_to: type=gha,mode=min
           - docker_target: nocache
             docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-nocache
-            caching: disabled
+            caching: none
             cache_from:
             cache_to:
           - docker_target: autocache
             docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-auto
             caching: automatic
+            cache_from:
+            cache_to:
+          - docker_target: local-cache
+            docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-local
+            caching: local
             cache_from:
             cache_to:
     steps:

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -34,19 +34,19 @@ jobs:
       statuses: write
     strategy:
       matrix:
-        docker_target: ["cache", "nocache", "automatic"]
+        docker_target: ["explict-cache", "nocache", "autocache"]
         include:
-          - docker_target: cache
+          - docker_target: explict-cache
             docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-cache
             caching: enabled
             cache_from: type=gha
-            cache_to: type=gha,mode=max
+            cache_to: type=gha,mode=min
           - docker_target: nocache
             docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-nocache
             caching: disabled
             cache_from:
             cache_to:
-          - docker_target: automatic
+          - docker_target: autocache
             docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-auto
             caching: automatic
             cache_from:
@@ -77,6 +77,8 @@ jobs:
           load_locally: true
           dockerfile: docker-image-builder/Dockerfile.test
           image_platforms: linux/amd64
+          enable_build_summary: false
+          enable_build_record: false
           dockerhub_image_name: ${{ matrix.docker_image_name }}
           caching: ${{ matrix.caching }}
           cache_from: ${{ matrix.cache_from }}

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -30,8 +30,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      issues: write
-      statuses: write
     strategy:
       matrix:
         docker_target: ["explict-cache", "nocache", "autocache"]

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -32,6 +32,25 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+    strategy:
+      matrix:
+        docker_target: ["cache", "nocache", "automatic"]
+        include:
+          - docker_target: cache
+            docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-cache
+            caching: enabled
+            cache_from: type=gha
+            cache_to: type=gha,mode=max
+          - docker_target: nocache
+            docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-nocache
+            caching: disabled
+            cache_from:
+            cache_to:
+          - docker_target: automatic
+            docker_image_name: ${{ github.repository_owner }}/test-docker-image-builder-auto
+            caching: automatic
+            cache_from:
+            cache_to:
     steps:
       - name: step-security/harden-runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -50,14 +69,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Update Status
-        id: check_pending
-        uses: ./commit-status-and-label
-        if: github.event_name == 'pull_request'
-        with:
-          token: ${{ github.token }}
-          sha: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
-          state: "pending"
       - name: docker-image-builder
         id: docker
         uses: ./docker-image-builder
@@ -66,7 +77,10 @@ jobs:
           load_locally: true
           dockerfile: docker-image-builder/Dockerfile.test
           image_platforms: linux/amd64
-          dockerhub_image_name: ${{ github.repository_owner }}/test-docker-image-builder
+          dockerhub_image_name: ${{ matrix.docker_image_name }}
+          caching: ${{ matrix.caching }}
+          cache_from: ${{ matrix.cache_from }}
+          cache_to: ${{ matrix.cache_to }}
       - name: check outputs
         id: check_outputs
         env:
@@ -113,16 +127,6 @@ jobs:
             echo "Deleting $image"
             docker rmi "$image" || true
           done
-      - name: Check Status
-        id: check_outcome
-        if: |
-          (success() || failure()) &&
-          github.event_name == 'pull_request'
-        uses: ./commit-status-and-label
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
-          state: "${{ steps.docker_run.outcome }}"
 
   notification:
     name: notification

--- a/docker-image-builder/README.md
+++ b/docker-image-builder/README.md
@@ -34,22 +34,24 @@ Defaults are the values in parentheses
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|        INPUT         |  TYPE  | REQUIRED |     DEFAULT     |                                                 DESCRIPTION                                                 |
-|----------------------|--------|----------|-----------------|-------------------------------------------------------------------------------------------------------------|
-|      cache_from      | string |  false   |                 |   List of external cache sources for build-push-action (e.g., user/app:cache, type=local,src=path/to/dir)   |
-|       cache_to       | string |  false   |                 | List of cache export destinations for build-push-action (e.g., user/app:cache, type=local,dest=path/to/dir) |
-|      dockerfile      | string |   true   |                 |                                           Path to the dockerfile                                            |
-| dockerhub_image_name | string |  false   |                 |                                            Dockerhub image name                                             |
-|   dockerhub_token    | string |  false   |                 |                                               Dockerhub token                                               |
-|    dockerhub_user    | string |  false   |                 |                                             Dockerhub username                                              |
-| enable_build_record  | string |  false   |    `"false"`    |                                Docker Build Record Upload to build artifacts                                |
-|   ghcr_image_name    | string |  false   |                 |                            Github container registry image name (ghcr.io/x/y/z)                             |
-|      ghcr_token      | string |  false   |                 |                                   Token for the github container registry                                   |
-|      ghcr_user       | string |  false   |                 |                                     Github container registry username                                      |
-|   image_platforms    | string |  false   | `"linux/amd64"` |                                           Platforms to build for                                            |
-|   image_tag_suffix   | string |  false   |                 |                                          Suffix for the image name                                          |
-|     load_locally     | string |  false   |    `"false"`    |                   Whether to load the image locally if you want to use it in a later step                   |
-|    registry_push     | string |  false   |    `"false"`    |                                       Whether to push to the registry                                       |
+|        INPUT         |  TYPE  | REQUIRED |     DEFAULT     |                                                  DESCRIPTION                                                   |
+|----------------------|--------|----------|-----------------|----------------------------------------------------------------------------------------------------------------|
+|      cache_from      | string |  false   |                 |       List of external cache sources for build-push-action (e.g., type=gha), overrides automatic setting       |
+|       cache_to       | string |  false   |                 | List of cache export destinations for build-push-action (e.g., type=gha,mode=max), overrides automatic setting |
+|       caching        | string |  false   |  `"automatic"`  |                                   Automagically make a choice about caching                                    |
+|       context        | string |  false   |      `"."`      |                                     The Context to pass through to docker                                      |
+|      dockerfile      | string |   true   |                 |                                             Path to the dockerfile                                             |
+| dockerhub_image_name | string |  false   |                 |                                              Dockerhub image name                                              |
+|   dockerhub_token    | string |  false   |                 |                                                Dockerhub token                                                 |
+|    dockerhub_user    | string |  false   |                 |                                               Dockerhub username                                               |
+| enable_build_record  | string |  false   |    `"false"`    |                                 Docker Build Record Upload to build artifacts                                  |
+|   ghcr_image_name    | string |  false   |                 |                              Github container registry image name (ghcr.io/x/y/z)                              |
+|      ghcr_token      | string |  false   |                 |                                    Token for the github container registry                                     |
+|      ghcr_user       | string |  false   |                 |                                       Github container registry username                                       |
+|   image_platforms    | string |  false   | `"linux/amd64"` |                                             Platforms to build for                                             |
+|   image_tag_suffix   | string |  false   |                 |                                           Suffix for the image name                                            |
+|     load_locally     | string |  false   |    `"false"`    |                    Whether to load the image locally if you want to use it in a later step                     |
+|    registry_push     | string |  false   |    `"false"`    |                                        Whether to push to the registry                                         |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/docker-image-builder/README.md
+++ b/docker-image-builder/README.md
@@ -32,9 +32,9 @@ Defaults are the values in parentheses
 
 |        INPUT         |  TYPE  | REQUIRED |     DEFAULT     |                                                  DESCRIPTION                                                   |
 |----------------------|--------|----------|-----------------|----------------------------------------------------------------------------------------------------------------|
-|      cache_from      | string |  false   |                 |       List of external cache sources for build-push-action (e.g., type=gha), overrides automatic setting       |
-|       cache_to       | string |  false   |                 | List of cache export destinations for build-push-action (e.g., type=gha,mode=max), overrides automatic setting |
-|       caching        | string |  false   |  `"automatic"`  |                                   Automagically make a choice about caching                                    |
+|      cache_from      | string |  false   |                 |       List of external cache sources for build-push-action (e.g., type=gha), overrides 'caching' setting       |
+|       cache_to       | string |  false   |                 | List of cache export destinations for build-push-action (e.g., type=gha,mode=max), overrides 'caching' setting |
+|       caching        | string |  false   |  `"automatic"`  |            Automagically make a choice about caching, valid options being automatic, local, or none            |
 |       context        | string |  false   |      `"."`      |                                     The Context to pass through to docker                                      |
 |      dockerfile      | string |   true   |                 |                                             Path to the dockerfile                                             |
 | dockerhub_image_name | string |  false   |                 |                                              Dockerhub image name                                              |
@@ -78,3 +78,4 @@ It's a composite action that wraps the following actions:
 - docker/login-action
 - docker/metadata-action
 - docker/build-push-action
+- actions/cache (if you opt for a local cache)

--- a/docker-image-builder/README.md
+++ b/docker-image-builder/README.md
@@ -41,6 +41,7 @@ Defaults are the values in parentheses
 |   dockerhub_token    | string |  false   |                 |                                                Dockerhub token                                                 |
 |    dockerhub_user    | string |  false   |                 |                                               Dockerhub username                                               |
 | enable_build_record  | string |  false   |    `"false"`    |                                 Docker Build Record Upload to build artifacts                                  |
+| enable_build_summary | string |  false   |    `"true"`     |                                         Emit a docker builder summary                                          |
 |   ghcr_image_name    | string |  false   |                 |                              Github container registry image name (ghcr.io/x/y/z)                              |
 |      ghcr_token      | string |  false   |                 |                                    Token for the github container registry                                     |
 |      ghcr_user       | string |  false   |                 |                                       Github container registry username                                       |

--- a/docker-image-builder/README.md
+++ b/docker-image-builder/README.md
@@ -17,11 +17,7 @@ Defaults are the values in parentheses
 - name: docker-build-push
   uses: quotidian-ennui/actions-olio/docker-image-builder@main
   with:
-    registry_push: true | (false)
-    load_locally: (false) | true
     dockerfile: /path/to/Dockerfile
-    image_tag_suffix: suffix to add to the version if any ('')
-    image_platforms: platforms to build for (linux/amd64)
     ghcr_image_name: your image name on ghcr.io
     dockerhub_image_name: your image on hub.docker.com
     ghcr_user: ${{ github.repository_owner }}

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -92,13 +92,16 @@ runs:
         if [[ "$CACHE_TO" == "" && "$CACHE_FROM" == "" ]]; then
           case "$CACHE_MODE" in
             automatic)
-              printf "cache_to=%s\n" "type=gha" | tee -a "$GITHUB_OUTPUT"
-              printf "cache_from=%s\n" "type=gha,mode=max" | tee -a "$GITHUB_OUTPUT"
-              printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_to=%s\n" "type=gha,mode=max" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_from=%s\n" "type=gha" | tee -a "$GITHUB_OUTPUT"#
               printf "cache_location=%s\n" "gha" | tee -a "$GITHUB_OUTPUT"
+              if [[ "$ON_DEFAULT_BRANCH" == "true" ]]; then
+                printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+              else
+                printf "caching=%s\n" "false" | tee -a "$GITHUB_OUTPUT"
+              fi
               ;;
             local)
-              cache_source=
               printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
               printf "local_cache_src=%s\n" "$LOCAL_CACHE_SOURCE" | tee -a "$GITHUB_OUTPUT"
               printf "local_cache_dest=%s\n" "$LOCAL_CACHE_DEST" | tee -a "$GITHUB_OUTPUT"
@@ -229,7 +232,8 @@ runs:
         LOCAL_CACHE_DEST: ${{ steps.bootstrap.outputs.local_cache_dest }}
       shell: bash
       run: |
-        if [[ -d "$LOCAL_CACHE_SOURCE" ]]; then
+        # https://github.com/docker/build-push-action/issues/252
+        if [[ -n "$LOCAL_CACHE_SOURCE" && -d "$LOCAL_CACHE_SOURCE" ]]; then
           rm "$LOCAL_CACHE_SOURCE"
           mv "$LOCAL_CACHE_DEST" "$LOCAL_CACHE_SOURCE"
         fi

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: Docker Build Record Upload to build artifacts
     required: false
     default: "false"
+  enable_build_summary:
+    description: Emit a docker builder summary
+    required: false
+    default: "true"
 
 outputs:
   image_tags:
@@ -146,6 +150,7 @@ runs:
       uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       env:
         DOCKER_BUILD_RECORD_UPLOAD: ${{ inputs.enable_build_record }}
+        DOCKER_BUILD_SUMMARY: ${{ inputs.enable_build_summary }}
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: ${{ inputs.context }}
@@ -164,6 +169,7 @@ runs:
       if: ${{ steps.bootstrap.outputs.caching != 'true' }}
       env:
         DOCKER_BUILD_RECORD_UPLOAD: ${{ inputs.enable_build_record }}
+        DOCKER_BUILD_SUMMARY: ${{ inputs.enable_build_summary }}
       with:
         no-cache: true
         builder: ${{ steps.buildx.outputs.name }}

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -89,6 +89,7 @@ runs:
         LOCAL_CACHE_SOURCE: "${{ runner.temp }}/.buildx-cache"
         LOCAL_CACHE_DEST: "${{ runner.temp }}/.buildx-cache-rebuild"
       run: |
+        echo "::group::docker-cache-settings"
         if [[ "$CACHE_TO" == "" && "$CACHE_FROM" == "" ]]; then
           case "$CACHE_MODE" in
             automatic)
@@ -124,6 +125,7 @@ runs:
           printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
           printf "cache_location=%s\n" "external" | tee -a "$GITHUB_OUTPUT"
         fi
+        echo "::endgroup::"
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -141,8 +143,9 @@ runs:
       if: steps.bootstrap.outputs.cache_location == 'local' && steps.bootstrap.outputs.rw_cache == 'false'
       with:
         path: ${{ steps.bootstrap.outputs.local_cache_src }}
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx-
+        key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ hashFiles('${{ inputs.dockerfile }}') }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
 
     - name: Cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -233,7 +236,10 @@ runs:
       shell: bash
       run: |
         # https://github.com/docker/build-push-action/issues/252
+        echo "::group::docker-cache-settings"
         if [[ -n "$LOCAL_CACHE_SOURCE" && -d "$LOCAL_CACHE_SOURCE" ]]; then
+          echo "ensure cache doesn't 'infinitely grow'"
           rm "$LOCAL_CACHE_SOURCE"
           mv "$LOCAL_CACHE_DEST" "$LOCAL_CACHE_SOURCE"
         fi
+        echo "::endgroup::"

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -2,11 +2,19 @@ name: Docker Build
 description: Build and optionally publish a docker image.
 inputs:
   cache_from:
-    description: "List of external cache sources for build-push-action (e.g., user/app:cache, type=local,src=path/to/dir)"
+    description: "List of external cache sources for build-push-action (e.g., type=gha), overrides automatic setting"
     required: false
   cache_to:
-    description: "List of cache export destinations for build-push-action (e.g., user/app:cache, type=local,dest=path/to/dir)"
+    description: "List of cache export destinations for build-push-action (e.g., type=gha,mode=max), overrides automatic setting"
     required: false
+  caching:
+    description: "Automagically make a choice about caching"
+    required: false
+    default: "automatic"
+  context:
+    description: "The Context to pass through to docker"
+    required: false
+    default: "."
   registry_push:
     description: Whether to push to the registry
     required: false
@@ -66,11 +74,37 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Bootstrap
+      id: bootstrap
+      shell: bash
+      env:
+        CACHE_MODE: ${{ inputs.caching }}
+        CACHE_TO: ${{ inputs.cache_to }}
+        CACHE_FROM: ${{ inputs.cache_from }}
+      run: |
+        if [[ "$CACHE_TO" == "" && "$CACHE_FROM" == "" ]]; then
+          if [[ "$CACHE_MODE" == "automatic" ]]; then
+            printf "cache_to=%s\n" "type=gha" | tee -a "$GITHUB_OUTPUT"
+            printf "cache_from=%s\n" "type=gha,mode=max" | tee -a "$GITHUB_OUTPUT"
+            printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+          else
+            printf "caching=%s\n" "false" | tee -a "$GITHUB_OUTPUT"
+          fi
+        else
+          printf "cache_to=%s\n" "$CACHE_TO" | tee -a "$GITHUB_OUTPUT"
+          printf "cache_from=%s\n" "$CACHE_FROM" | tee -a "$GITHUB_OUTPUT"
+          printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+        fi
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      with:
+        cache-image: ${{ steps.bootstrap.outputs.caching == 'true' }}
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      with:
+        cache-binary: ${{ steps.bootstrap.outputs.caching == 'true' }}
     - name: Login to DockerHub
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       if: |
@@ -106,14 +140,15 @@ runs:
           type=semver,pattern={{major}}
           type=ref,event=pr,priority=100
           type=raw,value=latest,enable={{is_default_branch}}
-    - name: Build Image
+    - name: Build Image (with caching)
+      if: ${{ steps.bootstrap.outputs.caching == 'true' }}
+      id: build_cache
       uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       env:
         DOCKER_BUILD_RECORD_UPLOAD: ${{ inputs.enable_build_record }}
       with:
-        # no-cache: true
         builder: ${{ steps.buildx.outputs.name }}
-        context: .
+        context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         platforms: ${{ inputs.image_platforms }}
         push: ${{ inputs.registry_push }}
@@ -121,5 +156,22 @@ runs:
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
         provenance: false
-        cache-from: ${{ inputs.cache_from }}
-        cache-to: ${{ inputs.cache_to }}
+        cache-from: ${{ steps.bootstrap.outputs.cache_from }}
+        cache-to: ${{ steps.bootstrap.outputs.cache_to }}
+    - name: Build Image (no-cache)
+      id: build_nocache
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      if: ${{ steps.bootstrap.outputs.caching != 'true' }}
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: ${{ inputs.enable_build_record }}
+      with:
+        no-cache: true
+        builder: ${{ steps.buildx.outputs.name }}
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.image_platforms }}
+        push: ${{ inputs.registry_push }}
+        load: ${{ inputs.load_locally }}
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        provenance: false

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -2,13 +2,13 @@ name: Docker Build
 description: Build and optionally publish a docker image.
 inputs:
   cache_from:
-    description: "List of external cache sources for build-push-action (e.g., type=gha), overrides automatic setting"
+    description: "List of external cache sources for build-push-action (e.g., type=gha), overrides 'caching' setting"
     required: false
   cache_to:
-    description: "List of cache export destinations for build-push-action (e.g., type=gha,mode=max), overrides automatic setting"
+    description: "List of cache export destinations for build-push-action (e.g., type=gha,mode=max), overrides 'caching' setting"
     required: false
   caching:
-    description: "Automagically make a choice about caching"
+    description: "Automagically make a choice about caching, valid options being automatic, local, or none"
     required: false
     default: "automatic"
   context:
@@ -85,30 +85,71 @@ runs:
         CACHE_MODE: ${{ inputs.caching }}
         CACHE_TO: ${{ inputs.cache_to }}
         CACHE_FROM: ${{ inputs.cache_from }}
+        ON_DEFAULT_BRANCH: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        LOCAL_CACHE_SOURCE: "${{ runner.temp }}/.buildx-cache"
+        LOCAL_CACHE_DEST: "${{ runner.temp }}/.buildx-cache-rebuild"
       run: |
         if [[ "$CACHE_TO" == "" && "$CACHE_FROM" == "" ]]; then
-          if [[ "$CACHE_MODE" == "automatic" ]]; then
-            printf "cache_to=%s\n" "type=gha" | tee -a "$GITHUB_OUTPUT"
-            printf "cache_from=%s\n" "type=gha,mode=max" | tee -a "$GITHUB_OUTPUT"
-            printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
-          else
-            printf "caching=%s\n" "false" | tee -a "$GITHUB_OUTPUT"
-          fi
+          case "$CACHE_MODE" in
+            automatic)
+              printf "cache_to=%s\n" "type=gha" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_from=%s\n" "type=gha,mode=max" | tee -a "$GITHUB_OUTPUT"
+              printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_location=%s\n" "gha" | tee -a "$GITHUB_OUTPUT"
+              ;;
+            local)
+              cache_source=
+              printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+              printf "local_cache_src=%s\n" "$LOCAL_CACHE_SOURCE" | tee -a "$GITHUB_OUTPUT"
+              printf "local_cache_dest=%s\n" "$LOCAL_CACHE_DEST" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_from=%s\n" "type=local,src=$LOCAL_CACHE_SOURCE" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_to=%s\n" "type=local,dest=$LOCAL_CACHE_DEST" | tee -a "$GITHUB_OUTPUT"
+              printf "cache_location=%s\n" "local" | tee -a "$GITHUB_OUTPUT"
+              if [[ "$ON_DEFAULT_BRANCH" == "true" ]]; then
+                printf "rw_cache=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+              else
+                printf "rw_cache=%s\n" "false" | tee -a "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              printf "caching=%s\n" "false" | tee -a "$GITHUB_OUTPUT"
+              ;;
+          esac
         else
           printf "cache_to=%s\n" "$CACHE_TO" | tee -a "$GITHUB_OUTPUT"
           printf "cache_from=%s\n" "$CACHE_FROM" | tee -a "$GITHUB_OUTPUT"
           printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
+          printf "cache_location=%s\n" "external" | tee -a "$GITHUB_OUTPUT"
         fi
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       with:
-        cache-image: ${{ steps.bootstrap.outputs.caching == 'true' }}
+        cache-image: ${{ steps.bootstrap.outputs.caching == 'true' && steps.bootstrap.outputs.cache_location != 'local' }}
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
-        cache-binary: ${{ steps.bootstrap.outputs.caching == 'true' }}
+        cache-binary: ${{ steps.bootstrap.outputs.caching == 'true' && steps.bootstrap.outputs.cache_location != 'local'}}
+
+    - name: ReadOnly Cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: ro-cache
+      if: steps.bootstrap.outputs.cache_location == 'local' && steps.bootstrap.outputs.rw_cache == 'false'
+      with:
+        path: ${{ steps.bootstrap.outputs.local_cache_src }}
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx-
+
+    - name: Cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: rw-cache
+      if: steps.bootstrap.outputs.cache_location == 'local' && steps.bootstrap.outputs.rw_cache == 'true'
+      with:
+        path: ${{ steps.bootstrap.outputs.local_cache_src }}
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-buildx-
+
     - name: Login to DockerHub
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       if: |
@@ -181,3 +222,14 @@ runs:
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
         provenance: false
+    - name: Local cache fixup
+      if: steps.bootstrap.outputs.cache_location == 'local' && steps.bootstrap.outputs.rw_cache == 'true'
+      env:
+        LOCAL_CACHE_SOURCE: ${{ steps.bootstrap.outputs.local_cache_src }}
+        LOCAL_CACHE_DEST: ${{ steps.bootstrap.outputs.local_cache_dest }}
+      shell: bash
+      run: |
+        if [[ -d "$LOCAL_CACHE_SOURCE" ]]; then
+          rm "$LOCAL_CACHE_SOURCE"
+          mv "$LOCAL_CACHE_DEST" "$LOCAL_CACHE_SOURCE"
+        fi


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- make a sensible choice about caching w/o having to specify.
- sensible choice could be a local cache?

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add automatic caching using github action cache
- add local cache using local filesystem.
- add matrix tests
- add 'enable_build_summary' input
- add 'context' input

<!-- SQUASH_MERGE_END -->

## Notes

- https://docs.docker.com/build/ci/github-actions/cache/#local-cache
  - local cache because then we do a thing with is_default_branch == true ?
  - ever growing cache etc.
- hard to test local caching because on main only.