### PR TITLE
feat(docker-image): add base image to local cache key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,13 @@ updates:
       setup-java-test:
         patterns:
           - "*"
+  - package-ecosystem: "docker"
+    directories:
+      - "src/test/docker-image-builder"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "03:23"
+      timezone: "Europe/London"
+    allow:
+      - dependency-type: "all"

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -21,6 +21,8 @@ jobs:
   actions_merge:
     runs-on: ubuntu-latest
     name: Dependabot Merge
+    if: |
+      github.event.client_payload.base.actor == 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-docker-image-builder.yml
+++ b/.github/workflows/test-docker-image-builder.yml
@@ -63,12 +63,14 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             auth.docker.io:443
-            dl-cdn.alpinelinux.org:443
             github.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
+            registry.access.redhat.com:443
+            cdn01.quay.io:443
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/docker-image-builder/action.yml
+++ b/docker-image-builder/action.yml
@@ -88,8 +88,15 @@ runs:
         ON_DEFAULT_BRANCH: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         LOCAL_CACHE_SOURCE: "${{ runner.temp }}/.buildx-cache"
         LOCAL_CACHE_DEST: "${{ runner.temp }}/.buildx-cache-rebuild"
+        DOCKERFILE: "${{ inputs.dockerfile }}"
       run: |
+
+        build_cache_name() {
+          cat "$DOCKERFILE" | grep FROM | head -n 1 | cut -d' ' -f 2 | cut -d':' -f 1
+        }
+
         echo "::group::docker-cache-settings"
+        cachekey="default"
         if [[ "$CACHE_TO" == "" && "$CACHE_FROM" == "" ]]; then
           case "$CACHE_MODE" in
             automatic)
@@ -103,6 +110,7 @@ runs:
               fi
               ;;
             local)
+              printf "local_cache_key=%s\n" "$(build_cache_name)" | tee -a "$GITHUB_OUTPUT"
               printf "caching=%s\n" "true" | tee -a "$GITHUB_OUTPUT"
               printf "local_cache_src=%s\n" "$LOCAL_CACHE_SOURCE" | tee -a "$GITHUB_OUTPUT"
               printf "local_cache_dest=%s\n" "$LOCAL_CACHE_DEST" | tee -a "$GITHUB_OUTPUT"
@@ -145,9 +153,10 @@ runs:
       if: steps.bootstrap.outputs.cache_location == 'local' && steps.bootstrap.outputs.rw_cache == 'false'
       with:
         path: ${{ steps.bootstrap.outputs.local_cache_src }}
-        key: ${{ runner.os }}-buildx-${{ hashFiles(inputs.dockerfile) }}-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ steps.bootstrap.outputs.local_cache_key }}-${{ hashFiles(inputs.dockerfile) }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-${{ hashFiles(inputs.dockerfile) }}-
+          ${{ runner.os }}-buildx-${{ steps.bootstrap.outputs.local_cache_key }}-${{ hashFiles(inputs.dockerfile) }}-
+          ${{ runner.os }}-buildx-${{ steps.bootstrap.outputs.local_cache_key }}-
           ${{ runner.os }}-buildx-
 
     - name: Cache
@@ -156,9 +165,10 @@ runs:
       if: steps.bootstrap.outputs.cache_location == 'local' && steps.bootstrap.outputs.rw_cache == 'true'
       with:
         path: ${{ steps.bootstrap.outputs.local_cache_src }}
-        key: ${{ runner.os }}-buildx-${{ hashFiles(inputs.dockerfile) }}-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ steps.bootstrap.outputs.local_cache_key }}-${{ hashFiles(inputs.dockerfile) }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-${{ hashFiles(inputs.dockerfile) }}-
+          ${{ runner.os }}-buildx-${{ steps.bootstrap.outputs.local_cache_key }}-${{ hashFiles(inputs.dockerfile) }}-
+          ${{ runner.os }}-buildx-${{ steps.bootstrap.outputs.local_cache_key }}-
           ${{ runner.os }}-buildx-
 
     - name: Login to DockerHub

--- a/src/test/docker-image-builder/Dockerfile.test
+++ b/src/test/docker-image-builder/Dockerfile.test
@@ -1,5 +1,4 @@
 # simple dockerfile for testing purposes
 # @see test-docker-image-builder.yml
-FROM alpine:latest
-RUN apk add --no-cache --update curl bash
-
+# ubi10 contains curl
+FROM registry.access.redhat.com/ubi10:10.2-1777462922


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add base image to local cache key
- use ubi10 image since it has '/' in the computed name
- add dependabot configuration for dockerfile

<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->
