### PR TITLE
refactor: switch to self-repository reference

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -142,12 +142,12 @@ release tag push="localonly":
     check_uptodate
     push="{{ push }}"
     next=$(echo "{{ tag }}" | sed -E 's/^v?/v/')
-    switch_reference "main" "$next"
+    # switch_reference "main" "$next"
     git tag "$next" -m"release $next"
-    switch_reference "$next" "main"
+    # switch_reference "$next" "main"
     case "$push" in
       push|github|gh)
-        git push --all
+        # git push --all
         git push --tags
         ;;
       *)

--- a/dependabot-merge/action.yml
+++ b/dependabot-merge/action.yml
@@ -134,7 +134,7 @@ runs:
         echo "summary_body_file=$summary_body_file" >> "$GITHUB_OUTPUT"
     - name: Update PR
       id: comment
-      uses: quotidian-ennui/actions-olio/pr-or-issue-comment@main
+      uses: $/pr-or-issue-comment
       if: |
         steps.bootstrap.outputs.is_dependabot_pr == 'true'
       with:
@@ -191,7 +191,7 @@ runs:
       if: |
         (success() || failure()) &&
         steps.bootstrap.outputs.automerge == 'true'
-      uses: quotidian-ennui/actions-olio/pr-or-issue-comment@main
+      uses: $/pr-or-issue-comment
       with:
         issue_number: ${{ github.event.client_payload.detail.pull_request }}
         body: |

--- a/pr-trigger/action.yml
+++ b/pr-trigger/action.yml
@@ -27,7 +27,7 @@ runs:
       uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
     - name: dispatch
       id: dispatch
-      uses: quotidian-ennui/actions-olio/repo-dispatch@main
+      uses: $/repo-dispatch
       with:
         event_type: "${{ inputs.event_type }}"
         token: ${{ inputs.token }}


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- refactor: switch to self-repository reference


<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->
